### PR TITLE
Fixing regex so that ACE tokenizer can work properly

### DIFF
--- a/ancilla/ezhil-ace/ezhil_highlight_rules.js
+++ b/ancilla/ezhil-ace/ezhil_highlight_rules.js
@@ -23,7 +23,7 @@ var EzhilHighlightRules = function() {
     var exponentFloat = "(?:(?:" + pointFloat + "|" +  intPart + ")" + exponent + ")";
     var floatNumber = "(?:" + exponentFloat + "|" + pointFloat + ")";
 
-    var stringEscape =  "";
+    var stringEscape =  "\\\\(x[0-9A-Fa-f]{2}|[0-7]{3}|[\\\\abfnrtv'\"])";
 	
    this.$rules = {
         "start" : [ {


### PR DESCRIPTION
Earlier not all Ezhil programs used to work with ACE as the regex was incomplete leaving the tokenizer to hang in the middle. Fixed it through this code change.
