### PR TITLE
Fixed filename issue

### DIFF
--- a/editor/ezhuthi.py
+++ b/editor/ezhuthi.py
@@ -18,6 +18,9 @@ import json
 import gi
 import tamil
 
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 gi.require_version('Gtk','3.0')
 try:
     from gi.repository import Gtk, GObject, GLib, Pango


### PR DESCRIPTION
While executing the program, The editor is asking to save the file again and again even after saving the file (filename in Tamil).
It works fine if we provide the filename in English.
I have added 'utf8' as default encoding. This is resolved the issue.